### PR TITLE
Catch null message bodies caused by status updates

### DIFF
--- a/bundles/action/org.openhab.action.xmpp/src/main/java/org/openhab/action/xmpp/internal/XMPPConsole.java
+++ b/bundles/action/org.openhab.action.xmpp/src/main/java/org/openhab/action/xmpp/internal/XMPPConsole.java
@@ -61,7 +61,7 @@ public class XMPPConsole implements ChatManagerListener, MessageListener {
 
 	public void processMessage(Chat chat, Message msg) {
 		logger.debug("Received XMPP message: {} of type {}", msg.getBody(), msg.getType());
-		if (msg.getType() == Message.Type.error) {
+		if (msg.getType() == Message.Type.error || msg.getBody() == null) {
 			return;
 		}
 		String cmd = msg.getBody();


### PR DESCRIPTION
Some messages of Type.chat contain no body, as in "xyz is typing..." notifications. These cause exceptions in the split later on. Returning on those keeps the logs clean.